### PR TITLE
Improve error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ toml = "0.5.3"
 failure = "0.1.6"
 derive_more = "0.15.0"
 glob = "0.3"
+difference = "2.0.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,13 @@ use std::thread;
 
 pub mod common;
 mod expand;
+mod message;
 
 #[derive(Debug, Fail, From)]
 pub enum Error {
+    #[fail(display = "Failed to execute `cargo expand`: {}", _0)]
+    CargoExpandExecutionError(String),
+
     #[fail(display = "I/O error: {}", _0)]
     IoError(#[cause] std::io::Error),
 
@@ -39,8 +43,9 @@ type Result<T> = std::result::Result<T, Error>;
 #[derive(Debug)]
 enum ExpansionOutcome {
     Same,
-    Different,
-    New,
+    Different(Vec<u8>, Vec<u8>),
+    New(Vec<u8>),
+    ExpandError(Vec<u8>),
 }
 
 #[derive(Debug)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,48 @@
+use difference::Changeset;
+
+/// Prints the difference of the two snippets of expanded code.
+pub fn message_different(name: &str, a: &[u8], b: &[u8]) {
+    let a = String::from_utf8_lossy(&a);
+    let b = String::from_utf8_lossy(&b);
+
+    let changes = Changeset::new(&a, &b, "\n");
+
+    eprintln!("{} - different!", name);
+
+    eprintln!();
+    eprintln!("--------------------------");
+    eprintln!("{}", changes.to_string());
+    eprintln!("--------------------------");
+
+}
+
+/// Prints an error from `cargo expand` invocation.
+/// Makes some suggestions when possible.
+pub fn message_expansion_error(msg: Vec<u8>) {
+    let msg = String::from_utf8(msg);
+
+    eprintln!("Expansion error:");
+    if let Ok(msg) = msg {
+        eprintln!("{}", msg);
+
+        // No `cargo expand` subcommand installed, make a suggestion
+        if msg.contains("no such subcommand: `expand`") {
+            eprintln!("Perhaps, `cargo expand` is not installed?");
+            eprintln!("Install it by running:");
+            eprintln!();
+            eprintln!("\tcargo install cargo-expand");
+            eprintln!();
+        }
+
+        // No nightly installed, make a suggestion
+        if msg.starts_with("error: toolchain '") && msg.ends_with("is not installed") {
+            eprintln!("You have `cargo expand` installed but it requires *nightly* compiler to be installed as well.");
+            eprintln!("To install it via rustup, run:");
+            eprintln!();
+            eprintln!("\trustup toolchain install nightly");
+            eprintln!();
+        }
+    } else {
+        eprintln!("<unprintable>");
+    }
+}

--- a/test-project/Cargo.lock
+++ b/test-project/Cargo.lock
@@ -52,6 +52,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +101,7 @@ name = "macrotest"
 version = "0.1.0"
 dependencies = [
  "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -326,6 +332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -1,5 +1,4 @@
 use macrotest::TestCases;
-use std::env::current_dir;
 
 #[test]
 pub fn run() {


### PR DESCRIPTION
* Print a `diff` in case of `.expanded.rs` content difference from the expansion result
* Fail on any `cargo expand` errors with some suggestions
* Refactor error messages into separate module