### PR TITLE
expand: Replace matches! macro by simple destructuring

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -344,7 +344,7 @@ impl ExpandedTest {
         let output = normalize_expansion(&output_bytes);
 
         if !expanded.exists() {
-            if matches!(expansion_behavior, ExpansionBehavior::ExpectFiles) {
+            if let ExpansionBehavior::ExpectFiles = expansion_behavior {
                 return Ok(ExpansionOutcome::NoExpandedFileFound);
             }
 


### PR DESCRIPTION
This allows the crate to build on versions of Rust below 1.42, more
specifically on 1.34.2, which is the Rust version shipped within Debian
Stable.

While I get that it isn't exactly intuitive to be compatible with an old
version of Rust while requiring a nightly toolchain to actually use the
tests, it allows client crates to run the expanded tests on said
version of Rust, allowing them to check that their code is compatible
with 1.34.

This PR is indirectly in support of https://github.com/rebpf/rebpf/pull/20