### PR TITLE
Provide a way to control updates of expanded.rs files via environment variable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub(crate) enum Error {
     GlobPatternError(glob::PatternError),
     ManifestDirError,
     PkgName,
+    UnrecognizedEnv(std::ffi::OsString),
 }
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
@@ -33,6 +34,11 @@ impl std::fmt::Display for Error {
             GlobPatternError(e) => write!(f, "{}", e),
             ManifestDirError => write!(f, "could not find CARGO_MANIFEST_DIR env var"),
             PkgName => write!(f, "could not find CARGO_PKG_NAME env var"),
+            UnrecognizedEnv(e) => write!(
+                f,
+                "unrecognized value of MACROTEST: \"{}\"",
+                e.to_string_lossy()
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,10 +111,11 @@
 //!
 //! ## Updating `.expanded.rs`
 //!
-//! This applicable only to tests that are using [`expand`] function.
+//! This applicable only to tests that are using [`expand`] or [`expand_args`] function.
 //!
-//! Remove the `*.expanded.rs` files and re-run the corresponding tests. Files will be created
-//! automatically; hand-writing them is not recommended.
+//! Run tests with the environment variable `MACROTEST=overwrite` or remove the `*.expanded.rs`
+//! files and re-run the corresponding tests. Files will be created automatically; hand-writing
+//! them is not recommended.
 //!
 //! [`expand_without_refresh`]: expand/fn.expand_without_refresh.html
 //! [`expand_without_refresh_args`]: expand/fn.expand_without_refresh_args.html


### PR DESCRIPTION
This adds a way to control updates of `*.expanded.rs` files via environment variable `MACROTEST=overwrite`.

**Motivation**: 
I'm using `macrotest` in [`pin-project`](https://github.com/taiki-e/pin-project/tree/1912a597802c04facb016a5f6324089acc56550b/tests/expand), but it's painful to manually remove the `*.expanded.rs` files every time I run the test, and I'm currently using [a script like this](https://github.com/taiki-e/pin-project/blob/1912a597802c04facb016a5f6324089acc56550b/scripts/expandtest.sh). Unfortunately, that script isn't enough either, and if I interrupt the test with ctrl-C or another way, `*.expanded.rs` files will remain removed. The ability to control these via environment variables is a method provided by similar tools such as [`trybuild`](https://github.com/dtolnay/trybuild#workflow) and [`insta`](https://github.com/mitsuhiko/insta#snapshot-updating), and seems to be a reasonable solution to this problem. It would be great if `macrotest` could support this.