### PR TITLE
Fix build failure on Rust 1.34

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -198,7 +198,7 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     let rand_string: String = thread_rng().sample_iter(&Alphanumeric).take(42).collect();
 
     let overwrite = match env::var_os("MACROTEST") {
-        Some(v) if v == "overwrite" => true,
+        Some(ref v) if v == "overwrite" => true,
         Some(v) => return Err(Error::UnrecognizedEnv(v)),
         None => false,
     };


### PR DESCRIPTION
cc #52
It was [my commit](https://github.com/eupn/macrotest/commit/518194750180c0c1f144779d9c7f5a460318f483#diff-4069e9bf14e9d4cb6fabb8d485623b6a5bb4d961eba5fa3e9d2293c221129186R201) that broke compatibility with Rust 1.34.