### PR TITLE
Support test files with same name in different dirs

### DIFF
--- a/test-project/tests/pr61/a/test.expanded.rs
+++ b/test-project/tests/pr61/a/test.expanded.rs
@@ -1,0 +1,5 @@
+#[macro_use]
+extern crate test_project;
+pub fn main() {
+    Vec::new();
+}

--- a/test-project/tests/pr61/a/test.rs
+++ b/test-project/tests/pr61/a/test.rs
@@ -1,0 +1,6 @@
+#[macro_use]
+extern crate test_project;
+
+pub fn main() {
+    test_vec![];
+}

--- a/test-project/tests/pr61/b/test.expanded.rs
+++ b/test-project/tests/pr61/b/test.expanded.rs
@@ -1,0 +1,5 @@
+#[macro_use]
+extern crate test_project;
+pub fn main() {
+    Vec::new();
+}

--- a/test-project/tests/pr61/b/test.rs
+++ b/test-project/tests/pr61/b/test.rs
@@ -1,0 +1,6 @@
+#[macro_use]
+extern crate test_project;
+
+pub fn main() {
+    test_vec![];
+}

--- a/test-project/tests/tests.rs
+++ b/test-project/tests/tests.rs
@@ -31,5 +31,14 @@ pub fn pass_expect_expanded_args() {
 #[should_panic]
 pub fn fail_expect_expanded_args() {
     // This directory doesn't have expanded files but since they're expected, the test will fail.
-    macrotest::expand_without_refresh_args("tests/no_expanded_args/*.rs", &["--features", "test-feature"]);
+    macrotest::expand_without_refresh_args(
+        "tests/no_expanded_args/*.rs",
+        &["--features", "test-feature"],
+    );
+}
+
+// https://github.com/eupn/macrotest/pull/61
+#[test]
+pub fn pr61() {
+    macrotest::expand("tests/pr61/*/*.rs");
 }


### PR DESCRIPTION
Currently, macrotest does not support test files with the same name in different dirs.

Repro:

```sh
cargo new --lib repro
cd repro
mkdir tests
mkdir tests/expand
mkdir tests/expand/a
mkdir tests/expand/b
echo 'macrotest = "1"' >> Cargo.toml
echo 'fn main() {}' > tests/expand/a/t.rs
echo 'fn main() {}' > tests/expand/b/t.rs
echo '#[test] fn expand() { macrotest::expand("tests/expand/*/*.rs") }' > tests/expandtest.rs
cargo test
```

Result:

```text
error: failed to parse manifest at `/Users/taiki/tmp/repro/target/tests/repro/mB6czU8BSkq7oGl4v9vaSYNOytDoCUaHoONbPeBDUF/Cargo.toml`
Caused by:
  found duplicate binary name t, but all binary targets must have a unique name
test expand ... FAILED

failures:

---- expand stdout ----
Running 2 macro expansion tests
Expansion error:
error: failed to parse manifest at `/Users/taiki/tmp/repro/target/tests/repro/mB6czU8BSkq7oGl4v9vaSYNOytDoCUaHoONbPeBDUF/Cargo.toml`
Caused by:
  found duplicate binary name t, but all binary targets must have a unique name

Expansion error:
error: failed to parse manifest at `/Users/taiki/tmp/repro/target/tests/repro/mB6czU8BSkq7oGl4v9vaSYNOytDoCUaHoONbPeBDUF/Cargo.toml`
Caused by:
  found duplicate binary name t, but all binary targets must have a unique name
```

This is because macrotest determines the test name based on the filename. The generated Cargo.toml contains bins with name conflicts such as:

```
[[bin]]
name = "t"
path = "/Users/taiki/tmp/repro/tests/expand/a/t.rs"

[[bin]]
name = "t"
path = "/Users/taiki/tmp/repro/tests/expand/b/t.rs"
```

This patch fixes the problem by giving bins a unique name. This is basically the same method that trybuild actually uses. (https://github.com/dtolnay/trybuild/commit/aa544645e9de881d2ca1dabe92984e56618eb7ca)