### PR TITLE
Set minimal serde version to 1.0.105

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ description = "Test harness for macro expansion"
 diff = "0.1"
 glob = "0.3"
 rand = "0.7.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.5"


### PR DESCRIPTION
Earlier versions either break the build or cause runtime errors so might as well specify the earliest version that will work.

Only tested on my machine when building [`duplicate`](https://github.com/Emoun/duplicate)