### PR TITLE
Ignore all the newer edition prelude imports

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -108,7 +108,7 @@ pub(crate) fn build_dependencies(project: &Project) -> Result<()> {
 const IGNORED_LINES: [&str; 5] = [
     "#![feature(prelude_import)]",
     "#[prelude_import]",
-    "use std::prelude::v1::*;",
+    "use std::prelude::",
     "#[macro_use]",
     "extern crate std;",
 ];


### PR DESCRIPTION
Without this, `use std::prelude::rust_2018::*;` gets printed to stdout by the following line prior to doing the tests.

https://github.com/eupn/macrotest/blob/779cfa5b70899a9793ba8be5f2d78fcb0eb0436f/src/cargo.rs#L100-L103

```console
running 1 test
    Updating crates.io index
    Checking serde_test_suite-tests v0.0.0 (/git/serde/target/tests/serde_test_suite/macrotest000)
    Finished dev [unoptimized + debuginfo] target(s) in 1.14s

use std::prelude::rust_2018::*;
tests/expand/de_enum.rs - ok
tests/expand/default_ty_param.rs - ok
tests/expand/generic_enum.rs - ok
tests/expand/generic_struct.rs - ok
tests/expand/generic_tuple_struct.rs - ok
tests/expand/lifetimes.rs - ok
tests/expand/named_map.rs - ok
tests/expand/named_tuple.rs - ok
tests/expand/named_unit.rs - ok
tests/expand/ser_enum.rs - ok
tests/expand/void.rs - ok
test expandtest ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 8.82s
```