### PR TITLE
Format using prettyplease instead of rustfmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ description = "Test harness for macro expansion"
 [dependencies]
 diff = "0.1"
 glob = "0.3"
+prettyplease = "0.1"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0"
+syn = { version = "1", features = ["full"] }
 toml = "0.5"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please refer to the [documentation](https://docs.rs/macrotest).
 
 ## Example
 
-Install nightly rust, [`cargo expand`] and [`rustfmt`].
+Install nightly rust and [`cargo expand`].
 
 Add to your crate's Cargo.toml:
 
@@ -43,5 +43,3 @@ See [test-project](test-project) and [test-procmacro-project](test-procmacro-pro
 
 [trybuild]: https://github.com/dtolnay/trybuild
 [`cargo expand`]: https://github.com/dtolnay/cargo-expand
-[`rustfmt`]: https://github.com/rust-lang/rustfmt
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,11 +76,6 @@
 //!
 //! A **nightly** compiler is required for this tool to work, so it must be installed as well.
 //!
-//! `cargo-expand` uses [`rustfmt`](https://github.com/rust-lang/rustfmt) to format expanded code.
-//! It's highly recommended to install it since the examples in the `test-project/` and
-//! `test-procmacro-project/` folders are using a formatted version of the expanded code
-//! to compare with.
-//!
 //! ## Setting up a test project
 //!
 //! In your crate that provides procedural or declarative macros, under the `tests` directory,

--- a/test-project/tests/expand_args/with_args.expanded.rs
+++ b/test-project/tests/expand_args/with_args.expanded.rs
@@ -1,4 +1,4 @@
-extern crate std;
+#![cfg(feature = "test-feature")]
 #[macro_use]
 extern crate test_project;
 pub fn main() {
@@ -10,3 +10,4 @@ pub fn main() {
         temp_vec
     };
 }
+


### PR DESCRIPTION
- Fixes #77.
- Separately, `prettyplease` is advantageous for this use case because the downstream repo can pin an exact version of it (`prettyplease = "=0.1.11"`) to completely isolate itself from formatting changes. This way we can ensure that our expand tests always pass when run by any user, regardless of what rustfmt version is installed on their system.