### PR TITLE
Support Edition 2021

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -34,6 +34,8 @@ pub enum Edition {
     E2015,
     #[serde(rename = "2018")]
     E2018,
+    #[serde(rename = "2021")]
+    E2021
 }
 
 #[derive(Serialize, Debug)]
@@ -60,7 +62,7 @@ pub struct Workspace {}
 
 impl Default for Edition {
     fn default() -> Self {
-        Edition::E2018
+        Edition::E2021
     }
 }
 


### PR DESCRIPTION
I just ran into this issue where if I depend on crates that uses the `2021` edition, the dependencies would not be added to the output `macrotestxxx` crate upon closer inspection.

This PR fixes this behaviour by simply adding a member to the `Edition` enum, thereby supporting the usage of the `2021` edition, which should be common now as it has been released some while ago already.