### PR TITLE
Use subdirectory within target/tests/

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -24,7 +24,7 @@ fn cargo(project: &Project) -> Command {
     cmd.current_dir(&project.dir);
     cmd.env(
         "CARGO_TARGET_DIR",
-        path!(project.target_dir / "tests" / "target"),
+        &project.inner_target_dir,
     );
     rustflags::set_env(&mut cmd);
     cmd

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -21,7 +21,8 @@ const EXPANDED_RS_SUFFIX: &str = "expanded.rs";
 pub(crate) struct Project {
     pub dir: PathBuf,
     source_dir: PathBuf,
-    pub target_dir: PathBuf,
+    /// Used for the inner runs of cargo()
+    pub inner_target_dir: PathBuf,
     pub name: String,
     pub features: Option<Vec<String>>,
     workspace: PathBuf,
@@ -204,10 +205,12 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
         fs::remove_dir_all(&dir)?;
     }
 
+    let inner_target_dir = path!(target_dir / "tests" / "macrotest");
+
     let mut project = Project {
         dir,
         source_dir,
-        target_dir,
+        inner_target_dir,
         name: format!("{}-tests", crate_name),
         features,
         workspace,
@@ -228,6 +231,8 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     fs::write(path!(project.dir / ".cargo" / "config"), config_toml)?;
     fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
     fs::write(path!(project.dir / "main.rs"), b"fn main() {}\n")?;
+
+    fs::create_dir_all(&project.inner_target_dir)?;
 
     cargo::build_dependencies(&project)?;
 


### PR DESCRIPTION
Use subdirectory within target/tests/

Or to put it another way, do not assume that the project's `target/tests/target/` is ours to use as we wish.

Specifically,
  * Change the the pathname to pass to cargo in `CARGO_TARGET_DIR` to add `/ "macrotest"` at the end.
  * Create it, which is now necessary, because it's not a parent of `project.dir`.
  * Construct it in `Project::prepare`, rather than in `cargo()`.  (Because the creation should be done in `prepare()`, not `cargo()`.)
  * So, pass the value though in a new `pub` field in `Project`.
  * Abolish the now-unused `target_dir` field of `Project`.

Empirically, this is sufficient on its own to resolve
  https://github.com/eupn/macrotest/issues/83
  https://github.com/dtolnay/trybuild/issues/218

(I don't know precisely what the difference is between trybuild's and macrotest's build invocations.  It is possible that it would be better for cargo to be able to cache both in the target directory, but I think we should use a namespaced directory, regardless.)

I have submitted a similar merge request https://github.com/dtolnay/trybuild/pull/219 for trybuild, which, likewise, is sufficient on its own to resolve the problem I was experiencing. I think these changes should be made to both packages.

Closes #83