### PR TITLE
Replace toml with basic-toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/eupn/macrotest"
 description = "Test harness for macro expansion"
 
 [dependencies]
+basic-toml = "0.1"
 diff = "0.1"
 glob = "0.3"
 prettyplease = "0.2"
 serde = { version = "1.0.105", features = ["derive"] }
 serde_json = "1.0"
 syn = { version = "2", features = ["full"] }
-toml = "0.5"

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -3,12 +3,12 @@ use crate::manifest::Edition;
 use serde::de::value::MapAccessDeserializer;
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::Value;
 use std::collections::BTreeMap as Map;
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use toml::Value;
 
 pub(crate) fn get_manifest(manifest_dir: &Path) -> Manifest {
     try_get_manifest(manifest_dir).unwrap_or_default()
@@ -17,7 +17,7 @@ pub(crate) fn get_manifest(manifest_dir: &Path) -> Manifest {
 fn try_get_manifest(manifest_dir: &Path) -> Result<Manifest, Error> {
     let cargo_toml_path = manifest_dir.join("Cargo.toml");
     let manifest_str = fs::read_to_string(cargo_toml_path)?;
-    let mut manifest: Manifest = toml::from_str(&manifest_str)?;
+    let mut manifest: Manifest = basic_toml::from_str(&manifest_str)?;
 
     fix_dependencies(&mut manifest.dependencies, manifest_dir);
     fix_dependencies(&mut manifest.dev_dependencies, manifest_dir);
@@ -32,7 +32,7 @@ pub(crate) fn get_workspace_manifest(manifest_dir: &Path) -> WorkspaceManifest {
 pub(crate) fn try_get_workspace_manifest(manifest_dir: &Path) -> Result<WorkspaceManifest, Error> {
     let cargo_toml_path = manifest_dir.join("Cargo.toml");
     let manifest_str = fs::read_to_string(cargo_toml_path)?;
-    let mut manifest: WorkspaceManifest = toml::from_str(&manifest_str)?;
+    let mut manifest: WorkspaceManifest = basic_toml::from_str(&manifest_str)?;
 
     fix_patches(&mut manifest.patch, manifest_dir);
     fix_replacements(&mut manifest.replace, manifest_dir);

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,8 +7,7 @@ pub(crate) enum Error {
     CargoFail,
     CargoMetadata(serde_json::error::Error),
     IoError(std::io::Error),
-    TomlSerError(toml::ser::Error),
-    TomlDeError(toml::de::Error),
+    TomlError(basic_toml::Error),
     GlobError(glob::GlobError),
     GlobPatternError(glob::PatternError),
     ManifestDirError,
@@ -28,8 +27,7 @@ impl std::fmt::Display for Error {
             CargoFail => write!(f, "cargo reported an error"),
             CargoMetadata(e) => write!(f, "{}", e),
             IoError(e) => write!(f, "{}", e),
-            TomlSerError(e) => write!(f, "{}", e),
-            TomlDeError(e) => write!(f, "{}", e),
+            TomlError(e) => write!(f, "{}", e),
             GlobError(e) => write!(f, "{}", e),
             GlobPatternError(e) => write!(f, "{}", e),
             ManifestDirError => write!(f, "could not find CARGO_MANIFEST_DIR env var"),
@@ -49,15 +47,9 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<toml::ser::Error> for Error {
-    fn from(e: toml::ser::Error) -> Self {
-        Error::TomlSerError(e)
-    }
-}
-
-impl From<toml::de::Error> for Error {
-    fn from(e: toml::de::Error) -> Self {
-        Error::TomlDeError(e)
+impl From<basic_toml::Error> for Error {
+    fn from(e: basic_toml::Error) -> Self {
+        Error::TomlError(e)
     }
 }
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -216,10 +216,10 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     };
 
     let manifest = make_manifest(crate_name, &project, tests)?;
-    let manifest_toml = toml::to_string(&manifest)?;
+    let manifest_toml = basic_toml::to_string(&manifest)?;
 
     let config = make_config();
-    let config_toml = toml::to_string(&config)?;
+    let config_toml = basic_toml::to_string(&config)?;
 
     if let Some(enabled_features) = &mut project.features {
         enabled_features.retain(|feature| manifest.features.contains_key(feature));

--- a/test-project/Cargo.lock
+++ b/test-project/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "basic-toml"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,13 +33,13 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 name = "macrotest"
 version = "1.0.9"
 dependencies = [
+ "basic-toml",
  "diff",
  "glob",
  "prettyplease",
  "serde",
  "serde_json",
  "syn",
- "toml",
 ]
 
 [[package]]
@@ -114,15 +123,6 @@ name = "test-project"
 version = "0.1.0"
 dependencies = [
  "macrotest",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]


### PR DESCRIPTION
As trybuild did (https://github.com/dtolnay/trybuild/commit/0e38544cb78e318f27364ed7e8c17aa0744c0e53), replace toml with [basic-toml](https://github.com/dtolnay/basic-toml).

As far as I know, basic-toml is faster to build and has fewer dependencies than toml 0.7. Also, the MSRV of toml 0.7 is 1.64, while the MSRV of basic-toml is 1.56, the same as the MSRV of macrotest.

Closes #86