### PR TITLE
Update CI config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,6 @@ updates:
     interval: daily
     time: "21:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: rand
-    versions:
-    - "> 0.7.3, < 1"
-  - dependency-name: rand
-    versions:
-    - ">= 0.8.a, < 0.9"
 - package-ecosystem: cargo
   directory: "/test-procmacro-project"
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
       - run: rustup toolchain install nightly
         if: matrix.rust != 'nightly'
 
-      - run: cargo install cargo-expand
+      - uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-expand
 
       - run: cargo test --manifest-path test-project/Cargo.toml -- --nocapture
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{matrix.rust}}
-          profile: minimal
-          override: true
+          toolchain: ${{ matrix.rust }}
 
       # A nightly toolchain is required for cargo-expand to work, even if the
       # toolchain with which tests are run is not nightly.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu, macos, windows]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions-rs/toolchain@v1
         with:


### PR DESCRIPTION
- Update outdated actions/checkout action to v4.
- Use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) action instead of unmaintained actions-rs/toolchain action. See https://github.com/tokio-rs/tokio/pull/5316 for more information.
- Cache cargo-expand using [taiki-e/cache-cargo-install-action](https://github.com/taiki-e/cache-cargo-install-action) action.
  no-cache:
  <img width="297" alt="before" src="https://github.com/eupn/macrotest/assets/43724913/5f79b275-715e-4afe-ab4b-a41a3398df71">
  with-cache:
  <img width="297" alt="after" src="https://github.com/eupn/macrotest/assets/43724913/d622ec6e-f2df-463c-8554-46f703e539c0">
  
- Remove outdated ignore list from dependabot config (unneeded since https://github.com/eupn/macrotest/pull/69)
