### PR TITLE
Version bump 1.0.9 -> 1.0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrotest"
-version = "1.0.9" # remember to update in lib.rs
+version = "1.0.10" # remember to update in lib.rs
 authors = ["eupn <eupn@protonmail.com>"]
 edition = "2018"
 rust-version = "1.56"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![crate_type = "lib"]
-#![doc(html_root_url = "https://docs.rs/macrotest/1.0.9")]
+#![doc(html_root_url = "https://docs.rs/macrotest/1.0.10")]
 
 //! #### &emsp; Test harness for macro expansion.
 //!


### PR DESCRIPTION
Changes:
- Update syn to 2.0 (https://github.com/eupn/macrotest/pull/91)
- Support edition 2021 and later (https://github.com/eupn/macrotest/pull/92)
- Replace toml with basic-toml (https://github.com/eupn/macrotest/pull/93)
- Use subdirectory within target/tests/ (https://github.com/eupn/macrotest/pull/84)
- Improve compile time (https://github.com/eupn/macrotest/pull/100)

Closes #94
Closes #98

Also closes #99, as I have been added as a collaborator and can create releases (not strictly related to this PR, though).