### PR TITLE
Inherit cargo-features field from source manifest

### DIFF
--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -74,6 +74,8 @@ pub struct WorkspaceManifest {
 
 #[derive(Deserialize, Default, Debug)]
 pub struct Manifest {
+    #[serde(default, rename = "cargo-features")]
+    pub cargo_features: Vec<String>,
     #[serde(default)]
     pub package: Package,
     #[serde(default)]

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -258,6 +258,7 @@ fn make_manifest(
         .collect();
 
     let mut manifest = Manifest {
+        cargo_features: source_manifest.cargo_features.clone(),
         package: Package {
             name: project.name.clone(),
             version: "0.0.0".to_owned(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -6,6 +6,9 @@ use std::path::PathBuf;
 
 #[derive(Serialize, Debug)]
 pub struct Manifest {
+    #[serde(rename = "cargo-features")]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cargo_features: Vec<String>,
     pub package: Package,
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub features: Map<String, Vec<String>>,


### PR DESCRIPTION
Needed to use cargo's unstable features, such as the 2024 edition.