### PR TITLE
Use .cargo/config.toml instead of .cargo/config

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -229,7 +229,7 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     }
 
     fs::create_dir_all(path!(project.dir / ".cargo"))?;
-    fs::write(path!(project.dir / ".cargo" / "config"), config_toml)?;
+    fs::write(path!(project.dir / ".cargo" / "config.toml"), config_toml)?;
     fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
     fs::write(path!(project.dir / "main.rs"), b"fn main() {}\n")?;
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -41,6 +41,6 @@ fn test_path_macro() {
         dir: PathBuf::from("../target/tests"),
     };
 
-    let cargo_dir = path!(project.dir / ".cargo" / "config");
-    assert_eq!(cargo_dir, Path::new("../target/tests/.cargo/config"));
+    let cargo_dir = path!(project.dir / ".cargo" / "config.toml");
+    assert_eq!(cargo_dir, Path::new("../target/tests/.cargo/config.toml"));
 }


### PR DESCRIPTION
Cargo now warns cargo/config:

```
warning: `/macrotest/test-project/target/tests/test-project/macrotest000/.cargo/config` is deprecated in favor of `config.toml`
note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
```