### PR TITLE
Remove mention about nightly toolchain which is no longer needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      # A nightly toolchain is required for cargo-expand to work, even if the
-      # toolchain with which tests are run is not nightly.
-      - run: rustup toolchain install nightly
-        if: matrix.rust != 'nightly'
-
       - uses: taiki-e/cache-cargo-install-action@v1
         with:
           tool: cargo-expand

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please refer to the [documentation](https://docs.rs/macrotest).
 
 ## Example
 
-Install nightly rust and [`cargo expand`].
+Install [`cargo expand`].
 
 Add to your crate's Cargo.toml:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,6 @@
 //! cargo install cargo-expand
 //! ```
 //!
-//! A **nightly** compiler is required for this tool to work, so it must be installed as well.
-//!
 //! ## Setting up a test project
 //!
 //! In your crate that provides procedural or declarative macros, under the `tests` directory,

--- a/src/message.rs
+++ b/src/message.rs
@@ -59,15 +59,6 @@ pub(crate) fn message_expansion_error(msg: Vec<u8>) {
             eprintln!("\tcargo install cargo-expand");
             eprintln!();
         }
-
-        // No nightly installed, make a suggestion
-        if msg.starts_with("error: toolchain '") && msg.ends_with("is not installed") {
-            eprintln!("You have `cargo expand` installed but it requires *nightly* compiler to be installed as well.");
-            eprintln!("To install it via rustup, run:");
-            eprintln!();
-            eprintln!("\trustup toolchain install nightly");
-            eprintln!();
-        }
     } else {
         eprintln!("<unprintable>");
     }


### PR DESCRIPTION
The latest cargo-expand doesn't require nightly toolchain (they are now using RUSTC_BOOTSTRAP on non-nightly toolchain: https://github.com/dtolnay/cargo-expand/pull/183).