### PR TITLE
Fix compat failures due to dependency updates (by honouring parent's dep versions)

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -233,6 +233,12 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     fs::write(path!(project.dir / "Cargo.toml"), manifest_toml)?;
     fs::write(path!(project.dir / "main.rs"), b"fn main() {}\n")?;
 
+    let source_lockfile = path!(project.workspace / "Cargo.lock");
+    match fs::copy(source_lockfile, path!(project.dir / "Cargo.lock")) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        otherwise => otherwise,
+    }?;
+
     fs::create_dir_all(&project.inner_target_dir)?;
 
     cargo::build_dependencies(&project)?;


### PR DESCRIPTION
Use Cargo.lock from workspace root (if available)

When using macrotest, to make output consistent, it is necessary to pin to a particular version of Nightly Rust.

But of course usptream Nightly Rust changes, and that means that dependencies (of the macro package under test) may need to be updated upstream.  Sometimes those updates aren't compatible with our pinned Nightly.

Therefore, tests must run with pinned versions of the dependencies, not just pinned versions of the compiler.  Without this, we can run into trouble, as seen here, for example:
  https://gitlab.torproject.org/Diziet/rust-derive-deftly/-/issues/60

Borrow a trick from dtolnay's trybuild, which faces the same problem: copy the outer workspace's Cargo.lock into the synthetic crate. This influences Cargo's resolver sufficiently; but since we run without --locked, Cargo can still adjust the file as needed for the synthetic crate.