### PR TITLE
Preserve optional dependencies when creating features in the expanded crate

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -256,10 +256,17 @@ fn make_manifest(
 
     let features = source_manifest
         .features
-        .keys()
-        .map(|feature| {
+        .iter()
+        .map(|(feature, source_deps)| {
             let enable = format!("{}/{}", crate_name, feature);
-            (feature.clone(), vec![enable])
+            let mut deps = vec![enable];
+            deps.extend(
+                source_deps
+                    .iter()
+                    .filter(|dep| dep.starts_with("dep:"))
+                    .cloned(),
+            );
+            (feature.clone(), deps)
         })
         .collect();
 


### PR DESCRIPTION
I found that when I had an optional dependency in a crate and a feature that depended on it with the same name, the expanded crate would not create explicit dependencies on the `dep:foo` optional features, and then Cargo would complain that `dep:foo` was unused.  For instance:

```
# Original my_crate Cargo.toml

[features]
foo = ["dep:foo", "other/foo"]

[dependencies]
foo = { version = "1.0.0", optional = true }
```

would give rise to

```
error: failed to parse manifest at `/.../macrotest000/Cargo.toml`

Caused by:
  optional dependency `foo` is not included in any feature
  Make sure that `dep:foo` is included in one of features in the [features] table.
```

because the generated `Cargo.toml` would look like

```
# macrotest generated Cargo.toml

[features]

foo = ["original_crate/foo"]

[dependencies]
foo = { version = "1.0.0", optional = true }
```

and the automatic `foo` feature would not be created.  This PR preserves all `dep:…` features when creating the expanded `Cargo.toml`:

```
# New macrotest generated Cargo.toml

[features]

foo = ["original_crate/foo", "dep:foo"]

[dependencies]
foo = { version = "1.0.0", optional = true }
```