### PR TITLE
Use toml_edit instead of basic-toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,14 +3,13 @@ name = "macrotest"
 version = "1.0.13" # remember to update in lib.rs
 authors = ["eupn <eupn@protonmail.com>"]
 edition = "2018"
-rust-version = "1.56"
+rust-version = "1.65"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/eupn/macrotest"
 description = "Test harness for macro expansion"
 
 [dependencies]
-basic-toml = "0.1"
 diff = "0.1"
 glob = "0.3"
 prettyplease = "0.2"
@@ -18,3 +17,4 @@ serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0"
 syn = { version = "2", features = ["full"] }
+toml_edit = { version = "0.22", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # `macrotest`
 
-[![Travis-CI](https://api.travis-ci.com/eupn/macrotest.svg?branch=master)](https://travis-ci.com/eupn/macrotest)
+[![Github Actions](https://img.shields.io/github/actions/workflow/status/eupn/macrotest/ci.yml?branch=master)](https://github.com/eupn/macrotest/actions)
 [![Crates.io](https://img.shields.io/crates/v/macrotest)](https://crates.io/crates/macrotest)
-![MSRV 1.56](https://img.shields.io/badge/MSRV-1.56-orange.svg)
+[![Crates.io (MSRV)](https://img.shields.io/crates/msrv/macrotest)](https://crates.io/crates/macrotest)
 [![docs.rs](https://docs.rs/macrotest/badge.svg)](https://docs.rs/macrotest/)
-[![Crates.io](https://img.shields.io/crates/d/macrotest)](https://crates.io/crates/macrotest)
-[![Crates.io](https://img.shields.io/crates/l/macrotest)](https://crates.io/crates/macrotest)
+[![Crates.io (Downloads)](https://img.shields.io/crates/d/macrotest)](https://crates.io/crates/macrotest)
+[![Crates.io (License)](https://img.shields.io/crates/l/macrotest)](https://crates.io/crates/macrotest)
 
 Similar to [trybuild], but allows you to test how declarative or procedural macros are expanded.
 
-*Minimal Supported Rust Version: 1.56*
+*Minimal Supported Rust Version: 1.65*
 
 ----
 

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -18,7 +18,7 @@ pub(crate) fn get_manifest(manifest_dir: &Path) -> Manifest {
 fn try_get_manifest(manifest_dir: &Path) -> Result<Manifest, Error> {
     let cargo_toml_path = manifest_dir.join("Cargo.toml");
     let manifest_str = fs::read_to_string(cargo_toml_path)?;
-    let mut manifest: Manifest = basic_toml::from_str(&manifest_str)?;
+    let mut manifest: Manifest = toml_edit::de::from_str(&manifest_str)?;
 
     fix_dependencies(&mut manifest.dependencies, manifest_dir);
     fix_dependencies(&mut manifest.dev_dependencies, manifest_dir);
@@ -33,7 +33,7 @@ pub(crate) fn get_workspace_manifest(manifest_dir: &Path) -> WorkspaceManifest {
 pub(crate) fn try_get_workspace_manifest(manifest_dir: &Path) -> Result<WorkspaceManifest, Error> {
     let cargo_toml_path = manifest_dir.join("Cargo.toml");
     let manifest_str = fs::read_to_string(cargo_toml_path)?;
-    let mut manifest: WorkspaceManifest = basic_toml::from_str(&manifest_str)?;
+    let mut manifest: WorkspaceManifest = toml_edit::de::from_str(&manifest_str)?;
 
     fix_dependencies(&mut manifest.workspace.dependencies, manifest_dir);
     fix_patches(&mut manifest.patch, manifest_dir);

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,8 @@ pub(crate) enum Error {
     CargoFail,
     CargoMetadata(serde_json::error::Error),
     Io(std::io::Error),
-    Toml(basic_toml::Error),
+    TomlSer(toml_edit::ser::Error),
+    TomlDe(toml_edit::de::Error),
     Glob(glob::GlobError),
     GlobPattern(glob::PatternError),
     ManifestDir,
@@ -25,7 +26,8 @@ impl std::fmt::Display for Error {
             CargoFail => write!(f, "cargo reported an error"),
             CargoMetadata(e) => write!(f, "{}", e),
             Io(e) => write!(f, "{}", e),
-            Toml(e) => write!(f, "{}", e),
+            TomlSer(e) => write!(f, "{}", e),
+            TomlDe(e) => write!(f, "{}", e),
             Glob(e) => write!(f, "{}", e),
             GlobPattern(e) => write!(f, "{}", e),
             ManifestDir => write!(f, "could not find CARGO_MANIFEST_DIR env var"),
@@ -45,9 +47,15 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<basic_toml::Error> for Error {
-    fn from(e: basic_toml::Error) -> Self {
-        Error::Toml(e)
+impl From<toml_edit::ser::Error> for Error {
+    fn from(e: toml_edit::ser::Error) -> Self {
+        Error::TomlSer(e)
+    }
+}
+
+impl From<toml_edit::de::Error> for Error {
+    fn from(e: toml_edit::de::Error) -> Self {
+        Error::TomlDe(e)
     }
 }
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -219,10 +219,10 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
     };
 
     let manifest = make_manifest(crate_name, &project, tests)?;
-    let manifest_toml = basic_toml::to_string(&manifest)?;
+    let manifest_toml = toml_edit::ser::to_string(&manifest)?;
 
     let config = make_config();
-    let config_toml = basic_toml::to_string(&config)?;
+    let config_toml = toml_edit::ser::to_string(&config)?;
 
     if let Some(enabled_features) = &mut project.features {
         enabled_features.retain(|feature| manifest.features.contains_key(feature));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! Similar to [trybuild], but allows you to write tests on how macros are expanded.
 //!
-//! *Minimal Supported Rust Version: 1.56*
+//! *Minimal Supported Rust Version: 1.65*
 //!
 //! <br>
 //!


### PR DESCRIPTION
See https://github.com/dtolnay/trybuild/issues/257.

The latest `toml` crate is based on `toml_edit` crate which has similar APIs, so use it directly.

Note: This increases MSRV to 1.65.