### PR TITLE
Use random string for crate dir again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Test harness for macro expansion"
 
 [dependencies]
 diff = "0.1"
+fastrand = "2"
 glob = "0.3"
 prettyplease = "0.2"
 serde = "1.0.105"

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -2,8 +2,8 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs;
 use std::io::Write;
+use std::iter;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::cargo;
 use crate::dependencies::{self, Dependency};
@@ -194,11 +194,10 @@ fn prepare(tests: &[ExpandedTest]) -> Result<Project> {
         None => false,
     };
 
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // Use unique string for the crate dir to
+    // Use random string for the crate dir to
     // prevent conflicts when running parallel tests.
-    let unique_string: String = format!("macrotest{:03}", COUNT.fetch_add(1, Ordering::SeqCst));
-    let dir = path!(target_dir / "tests" / crate_name / unique_string);
+    let random_string: String = iter::repeat_with(fastrand::alphanumeric).take(42).collect();
+    let dir = path!(target_dir / "tests" / crate_name / random_string);
     if dir.exists() {
         // Remove remaining artifacts from previous runs if exist.
         // For example, if the user stops the test with Ctrl-C during a previous


### PR DESCRIPTION
Fixes #113

Partially reverts https://github.com/eupn/macrotest/pull/69 and use more lightweight `fastrand` instead `rand`.

@wmmc88: Could you confirm that this actually fixes your problem?