### PR TITLE
fix(manifest): added `dev-dependencies` to Manifest

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -279,6 +279,7 @@ fn make_manifest(
         },
         features,
         dependencies: std::collections::BTreeMap::new(),
+        dev_dependencies: std::collections::BTreeMap::new(),
         bins: Vec::new(),
         workspace: Some(Workspace {
             package: crate::manifest::WorkspacePackage {
@@ -294,7 +295,7 @@ fn make_manifest(
 
     manifest.dependencies.extend(source_manifest.dependencies);
     manifest
-        .dependencies
+        .dev_dependencies
         .extend(source_manifest.dev_dependencies);
     manifest.dependencies.insert(
         crate_name,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -14,6 +14,8 @@ pub struct Manifest {
     #[serde(skip_serializing_if = "Map::is_empty")]
     pub features: Map<String, Vec<String>>,
     pub dependencies: Map<String, Dependency>,
+    #[serde(rename = "dev-dependencies")]
+    pub dev_dependencies: Map<String, Dependency>,
     #[serde(rename = "bin")]
     pub bins: Vec<Bin>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
A project like this
```toml
[package]
name = "test-project"
version = "0.1.0"
edition = "2018"

[lib]

[features]
default = []

test-feature = ["dep:tracing"]

[dev-dependencies]
macrotest = { path = "../" }
tracing = { version = "0.1.40" }

[dependencies]
tracing = { version = "0.1.40", default-features = false, optional = true }
```

where the same dependency is defined twice, as optional and as not optional, and there is a feature that requires this dependency, `macrotest` will fail with the following error:

```txt
Caused by:
  feature `test-feature` includes `dep:tracing`, but `tracing` is not an optional dependency
  A non-optional dependency of the same name is defined; consider adding `optional = true` to its definition.
```

This PR adds `dev-dependencies` to the manifest and extends the `manifest.dev_dependencies` instead of the `manifest.dependencies` with the `source_manifest.dev_dependencies`, which was causing the `dependencies` to be overridden by the `dev_dependencies`.