### PR TITLE
Disable default features of syn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "macrotest"
 version = "1.1.0"
 authors = ["eupn <eupn@protonmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.66"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ prettyplease = "0.2"
 serde = "1.0.105"
 serde_derive = "1.0.105"
 serde_json = "1.0"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", default-features = false, features = ["parsing", "full"] }
 toml = "0.9"


### PR DESCRIPTION
Align to [prettyplease](https://github.com/dtolnay/prettyplease/blob/9ae9017fbc654311750b5c411c3e061e588f4964/Cargo.toml#L22).

This results in a improvement in release build time of about 1 second overall macrotest and 1.5 seconds on syn unit. (On Apple M4 Pro)

The following is an excerpt from the report in --release --timings.

Before (total):
<img width="435" height="46" alt="before" src="https://github.com/user-attachments/assets/e55a79df-5e88-44fd-be89-3efc600e91d2" />
Before (total):
<img width="435" height="46" alt="after" src="https://github.com/user-attachments/assets/8066c49f-b95c-41da-946a-d3acebb4ab58" />


Before (unit):
<img width="955" height="110" alt="before" src="https://github.com/user-attachments/assets/d760f397-235c-43ce-832a-eceec58d3d27" />
After (unit):
<img width="872" height="98" alt="after" src="https://github.com/user-attachments/assets/4ff7c2dd-72d9-4f32-a919-b5faa2d8eebc" />

Note that Rust 2021 (which done in the first commit) or resolver 2 is needed for proper timing reports.