### PR TITLE
Version bump 1.1.0 -> 1.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "macrotest"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["eupn <eupn@protonmail.com>"]
 edition = "2021"
 rust-version = "1.66"


### PR DESCRIPTION
Changes:
- https://github.com/eupn/macrotest/pull/128
- https://github.com/eupn/macrotest/pull/129

Bumped minor version considering MSRV bump in #128 (1.65 -> 1.66).